### PR TITLE
fix logging for non-string values

### DIFF
--- a/CodeOnTheGo/CGLessonViewController.m
+++ b/CodeOnTheGo/CGLessonViewController.m
@@ -127,7 +127,7 @@
     }
     if ([self.log count]) {
 
-        [self.output setText:[self.log firstObject]];
+        [self.output setText:[self.log firstObject].stringValue];
         NSLog(@"%@", self.log);
         [self.log removeAllObjects];
         [self.view addSubview:self.output];


### PR DESCRIPTION
The error is that you are converting the returned value to an object, but that could be anything.

In the crashing case `console.log(5)` it's a number.

So we convert any object to string rep before setting the output text.
